### PR TITLE
add double quote to background image url because css can not recognise filename with space

### DIFF
--- a/src/ImageMagnifier.js
+++ b/src/ImageMagnifier.js
@@ -68,7 +68,7 @@ var Magnifier = React.createClass({
                 <div style={{
                     width: props.size,
                     height: props.size,
-                    backgroundImage: `url(${props.zoomImage.src})`,
+                    backgroundImage: `url("${props.zoomImage.src}")`,
                     backgroundRepeat: 'no-repeat',
                     backgroundPosition: `${bgX}px ${bgY}px`,
                     borderRadius: props.size


### PR DESCRIPTION
add double quote to background image url because css can not recognise filename with space

e.g. `background-image: url(sdfds/sdfa/adf sdf.jpg)` is not work but `background-image: url("sdfds/sdfa/adf sdf.jpg")` will work. 
